### PR TITLE
Make SwigObject a marco to support multiple types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,6 +114,11 @@ matrix:
       dist: xenial
     - compiler: gcc
       os: linux
+      env: SWIGLANG=javascript ENGINE=node VER=12 CPP11=1
+      sudo: required
+      dist: xenial
+    - compiler: gcc
+      os: linux
       env: SWIGLANG=javascript ENGINE=jsc
       sudo: required
       dist: xenial

--- a/Examples/javascript/native/example.i
+++ b/Examples/javascript/native/example.i
@@ -15,7 +15,11 @@ int placeholder() { return 0; }
     static SwigV8ReturnValue JavaScript_do_work(const SwigV8Arguments &args) {
         SWIGV8_HANDLESCOPE();
         const int MY_MAGIC_NUMBER = 5;
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
         v8::Handle<v8::Value> jsresult =
+#else
+        v8::Local<v8::Value> jsresult =
+#endif
             SWIG_From_int(static_cast< int >(MY_MAGIC_NUMBER));
         if (args.Length() != 0)
             SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments.");

--- a/Examples/test-suite/native_directive.i
+++ b/Examples/test-suite/native_directive.i
@@ -53,7 +53,11 @@ extern "C" JNIEXPORT jint JNICALL Java_native_1directive_native_1directiveJNI_Co
 
 static SwigV8ReturnValue JavaScript_alpha_count(const SwigV8Arguments &args) {
   SWIGV8_HANDLESCOPE();
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
   v8::Handle<v8::Value> jsresult;
+#else
+  v8::Local<v8::Value> jsresult;
+#endif
   char *arg1 = (char *)0;
   int res1;
   char *buf1 = 0;

--- a/Lib/javascript/v8/javascriptcode.swg
+++ b/Lib/javascript/v8/javascriptcode.swg
@@ -459,11 +459,14 @@ fail:
 #endif
   $jsmangledname_class_0->SetCallHandler($jsctor);
   $jsmangledname_class_0->Inherit($jsmangledname_class);
-  $jsmangledname_class_0->SetHiddenPrototype(true);
 #if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
+  $jsmangledname_class_0->SetHiddenPrototype(true);
   v8::Handle<v8::Object> $jsmangledname_obj = $jsmangledname_class_0->GetFunction();
-#else
+#elif (SWIG_V8_VERSION < 0x0705)
+  $jsmangledname_class_0->SetHiddenPrototype(true);
   v8::Local<v8::Object> $jsmangledname_obj = $jsmangledname_class_0->GetFunction();
+#else
+  v8::Local<v8::Object> $jsmangledname_obj = $jsmangledname_class_0->GetFunction(SWIGV8_CURRENT_CONTEXT()).ToLocalChecked();
 #endif
 %}
 
@@ -475,7 +478,12 @@ fail:
  * ----------------------------------------------------------------------------- */
 %fragment("jsv8_register_class", "templates")
 %{
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903) || (SWIG_V8_VERSION < 0x0706)
   $jsparent_obj->Set(SWIGV8_SYMBOL_NEW("$jsname"), $jsmangledname_obj);
+#else
+  $jsparent_obj->Set(SWIGV8_CURRENT_CONTEXT(), SWIGV8_SYMBOL_NEW("$jsname"), $jsmangledname_obj);
+#endif
+
 %}
 
 /* -----------------------------------------------------------------------------
@@ -499,7 +507,11 @@ fail:
  * ----------------------------------------------------------------------------- */
 %fragment("jsv8_register_namespace", "templates")
 %{
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903) || (SWIG_V8_VERSION < 0x0706)
   $jsparent_obj->Set(SWIGV8_SYMBOL_NEW("$jsname"), $jsmangledname_obj);
+#else
+  $jsparent_obj->Set(SWIGV8_CURRENT_CONTEXT(), SWIGV8_SYMBOL_NEW("$jsname"), $jsmangledname_obj);
+#endif
 %}
 
 /* -----------------------------------------------------------------------------

--- a/Lib/javascript/v8/javascriptcode.swg
+++ b/Lib/javascript/v8/javascriptcode.swg
@@ -11,7 +11,11 @@
 static SwigV8ReturnValue $jswrapper(const SwigV8Arguments &args) {
   SWIGV8_HANDLESCOPE();
   
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
   v8::Handle<v8::Object> self = args.Holder();
+#else
+  v8::Local<v8::Object> self = args.Holder();
+#endif
   $jslocals
   if(args.Length() != $jsargcount) SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments for $jswrapper.");
   $jscode
@@ -53,7 +57,11 @@ static SwigV8ReturnValue $jswrapper(const SwigV8Arguments &args) {
   SWIGV8_HANDLESCOPE();
   
   OverloadErrorHandler errorHandler;
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
   v8::Handle<v8::Value> self;
+#else
+  v8::Local<v8::Value> self;
+#endif
 
   // switch all cases by means of series of if-returns.
   $jsdispatchcases
@@ -78,7 +86,11 @@ fail:
 static SwigV8ReturnValue $jswrapper(const SwigV8Arguments &args, V8ErrorHandler &SWIGV8_ErrorHandler) {
   SWIGV8_HANDLESCOPE();
   
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
   v8::Handle<v8::Object> self = args.Holder();
+#else
+  v8::Local<v8::Object> self = args.Holder();
+#endif
   $jslocals
   if(args.Length() != $jsargcount) SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments for $jswrapper.");
   $jscode
@@ -226,7 +238,11 @@ static SwigV8ReturnValue $jswrapper(v8::Local<v8::Name> property, const SwigV8Pr
 #endif
   SWIGV8_HANDLESCOPE();
   
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
   v8::Handle<v8::Value> jsresult;
+#else
+  v8::Local<v8::Value> jsresult;
+#endif
   $jslocals
   $jscode
   SWIGV8_RETURN_INFO(jsresult, info);
@@ -271,7 +287,11 @@ fail:
 static SwigV8ReturnValue $jswrapper(const SwigV8Arguments &args) {
   SWIGV8_HANDLESCOPE();
   
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
   v8::Handle<v8::Value> jsresult;
+#else
+  v8::Local<v8::Value> jsresult;
+#endif
   $jslocals
   if(args.Length() != $jsargcount) SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments for $jswrapper.");
 
@@ -296,7 +316,11 @@ fail:
 static SwigV8ReturnValue $jswrapper(const SwigV8Arguments &args) {
   SWIGV8_HANDLESCOPE();
   
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
   v8::Handle<v8::Value> jsresult;
+#else
+  v8::Local<v8::Value> jsresult;
+#endif
   OverloadErrorHandler errorHandler;
   $jscode
 
@@ -320,7 +344,11 @@ static SwigV8ReturnValue $jswrapper(const SwigV8Arguments &args, V8ErrorHandler 
 {
   SWIGV8_HANDLESCOPE();
   
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
   v8::Handle<v8::Value> jsresult;
+#else
+  v8::Local<v8::Value> jsresult;
+#endif
   $jslocals
   $jscode
   SWIGV8_RETURN(jsresult);
@@ -374,7 +402,11 @@ fail:
 %fragment("jsv8_define_class_template", "templates")
 %{
   /* Name: $jsmangledname, Type: $jsmangledtype, Dtor: $jsdtor */
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
   v8::Handle<v8::FunctionTemplate> $jsmangledname_class = SWIGV8_CreateClassTemplate("$jsmangledname");
+#else
+  v8::Local<v8::FunctionTemplate> $jsmangledname_class = SWIGV8_CreateClassTemplate("$jsmangledname");
+#endif
   SWIGV8_SET_CLASS_TEMPL($jsmangledname_clientData.class_templ, $jsmangledname_class);
   $jsmangledname_clientData.dtor = $jsdtor;
   if (SWIGTYPE_$jsmangledtype->clientdata == 0) {
@@ -420,11 +452,19 @@ fail:
 %fragment("jsv8_create_class_instance", "templates")
 %{
   /* Class: $jsname ($jsmangledname) */
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
   v8::Handle<v8::FunctionTemplate> $jsmangledname_class_0 = SWIGV8_CreateClassTemplate("$jsname");
+#else
+  v8::Local<v8::FunctionTemplate> $jsmangledname_class_0 = SWIGV8_CreateClassTemplate("$jsname");
+#endif
   $jsmangledname_class_0->SetCallHandler($jsctor);
   $jsmangledname_class_0->Inherit($jsmangledname_class);
   $jsmangledname_class_0->SetHiddenPrototype(true);
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
   v8::Handle<v8::Object> $jsmangledname_obj = $jsmangledname_class_0->GetFunction();
+#else
+  v8::Local<v8::Object> $jsmangledname_obj = $jsmangledname_class_0->GetFunction();
+#endif
 %}
 
 /* -----------------------------------------------------------------------------
@@ -444,7 +484,11 @@ fail:
  * ----------------------------------------------------------------------------- */
 %fragment("jsv8_create_namespace", "templates")
 %{
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
   v8::Handle<v8::Object> $jsmangledname_obj = SWIGV8_OBJECT_NEW();
+#else
+  v8::Local<v8::Object> $jsmangledname_obj = SWIGV8_OBJECT_NEW();
+#endif
 %}
 
 /* -----------------------------------------------------------------------------

--- a/Lib/javascript/v8/javascriptcomplex.swg
+++ b/Lib/javascript/v8/javascriptcomplex.swg
@@ -12,7 +12,11 @@
 %fragment(SWIG_From_frag(Type),"header",
           fragment=SWIG_From_frag(double))
 {
+%#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 SWIGINTERNINLINE v8::Handle<v8::Value>
+%#else
+SWIGINTERNINLINE v8::Local<v8::Value>
+%#endif
 SWIG_From_dec(Type)(%ifcplusplus(const Type&, Type) c)
 {
   SWIGV8_HANDLESCOPE_ESC();
@@ -32,12 +36,20 @@ SWIG_From_dec(Type)(%ifcplusplus(const Type&, Type) c)
 	  fragment=SWIG_AsVal_frag(double))
 {
 SWIGINTERN int
+%#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 SWIG_AsVal_dec(Type) (v8::Handle<v8::Value> o, Type* val)
+%#else
+SWIG_AsVal_dec(Type) (v8::Local<v8::Value> o, Type* val)
+%#endif
 {
   SWIGV8_HANDLESCOPE();
   
   if (o->IsArray()) {
+%#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
     v8::Handle<v8::Array> array = v8::Handle<v8::Array>::Cast(o);
+%#else
+    v8::Local<v8::Array> array = v8::Local<v8::Array>::Cast(o);
+%#endif
     
     if(array->Length() != 2) SWIG_Error(SWIG_TypeError, "Illegal argument for complex: must be array[2].");
     double re, im;
@@ -74,12 +86,20 @@ SWIG_AsVal_dec(Type) (v8::Handle<v8::Value> o, Type* val)
 %fragment(SWIG_AsVal_frag(Type),"header",
           fragment=SWIG_AsVal_frag(float)) {
 SWIGINTERN int
+%#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 SWIG_AsVal_dec(Type) (v8::Handle<v8::Value> o, Type* val)
+%#else
+SWIG_AsVal_dec(Type) (v8::Local<v8::Value> o, Type* val)
+%#endif
 {
   SWIGV8_HANDLESCOPE();
 
   if (o->IsArray()) {
+%#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
     v8::Handle<v8::Array> array = v8::Handle<v8::Array>::Cast(o);
+%#else
+    v8::Local<v8::Array> array = v8::Local<v8::Array>::Cast(o);
+%#endif
     
     if(array->Length() != 2) SWIG_Error(SWIG_TypeError, "Illegal argument for complex: must be array[2].");
     double re, im;

--- a/Lib/javascript/v8/javascripthelpers.swg
+++ b/Lib/javascript/v8/javascripthelpers.swg
@@ -21,19 +21,35 @@ typedef v8::PropertyCallbackInfo<void>  SwigV8PropertyCallbackInfoVoid;
 /**
  * Creates a class template for a class with specified initialization function.
  */
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 SWIGRUNTIME v8::Handle<v8::FunctionTemplate> SWIGV8_CreateClassTemplate(const char* symbol) {
+#else
+SWIGRUNTIME v8::Local<v8::FunctionTemplate> SWIGV8_CreateClassTemplate(const char* symbol) {
+#endif
     SWIGV8_HANDLESCOPE_ESC();
     
     v8::Local<v8::FunctionTemplate> class_templ = SWIGV8_FUNCTEMPLATE_NEW_VOID();
     class_templ->SetClassName(SWIGV8_SYMBOL_NEW(symbol));
 
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
     v8::Handle<v8::ObjectTemplate> inst_templ = class_templ->InstanceTemplate();
+#else
+    v8::Local<v8::ObjectTemplate> inst_templ = class_templ->InstanceTemplate();
+#endif
     inst_templ->SetInternalFieldCount(1);
 
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
     v8::Handle<v8::ObjectTemplate> equals_templ = class_templ->PrototypeTemplate();
+#else
+    v8::Local<v8::ObjectTemplate> equals_templ = class_templ->PrototypeTemplate();
+#endif
     equals_templ->Set(SWIGV8_SYMBOL_NEW("equals"), SWIGV8_FUNCTEMPLATE_NEW(_SWIGV8_wrap_equals));
 
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
     v8::Handle<v8::ObjectTemplate> cptr_templ = class_templ->PrototypeTemplate();
+#else
+    v8::Local<v8::ObjectTemplate> cptr_templ = class_templ->PrototypeTemplate();
+#endif
     cptr_templ->Set(SWIGV8_SYMBOL_NEW("getCPtr"), SWIGV8_FUNCTEMPLATE_NEW(_wrap_getCPtr));
 
     SWIGV8_ESCAPE(class_templ);
@@ -42,34 +58,62 @@ SWIGRUNTIME v8::Handle<v8::FunctionTemplate> SWIGV8_CreateClassTemplate(const ch
 /**
  * Registers a class method with given name for a given class template.
  */
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 SWIGRUNTIME void SWIGV8_AddMemberFunction(v8::Handle<v8::FunctionTemplate> class_templ, const char* symbol,
   SwigV8FunctionCallback _func) {
+#else
+SWIGRUNTIME void SWIGV8_AddMemberFunction(v8::Local<v8::FunctionTemplate> class_templ, const char* symbol,
+  SwigV8FunctionCallback _func) {
+#endif
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
     v8::Handle<v8::ObjectTemplate> proto_templ = class_templ->PrototypeTemplate();
+#else
+    v8::Local<v8::ObjectTemplate> proto_templ = class_templ->PrototypeTemplate();
+#endif
     proto_templ->Set(SWIGV8_SYMBOL_NEW(symbol), SWIGV8_FUNCTEMPLATE_NEW(_func));
 }
 
 /**
  * Registers a class property with given name for a given class template.
  */
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 SWIGRUNTIME void SWIGV8_AddMemberVariable(v8::Handle<v8::FunctionTemplate> class_templ, const char* symbol,
   SwigV8AccessorGetterCallback getter, SwigV8AccessorSetterCallback setter) {
+#else
+SWIGRUNTIME void SWIGV8_AddMemberVariable(v8::Local<v8::FunctionTemplate> class_templ, const char* symbol,
+  SwigV8AccessorGetterCallback getter, SwigV8AccessorSetterCallback setter) {
+#endif
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
   v8::Handle<v8::ObjectTemplate> proto_templ = class_templ->InstanceTemplate();
+#else
+  v8::Local<v8::ObjectTemplate> proto_templ = class_templ->InstanceTemplate();
+#endif
   proto_templ->SetAccessor(SWIGV8_SYMBOL_NEW(symbol), getter, setter);
 }
 
 /**
  * Registers a class method with given name for a given object.
  */
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 SWIGRUNTIME void SWIGV8_AddStaticFunction(v8::Handle<v8::Object> obj, const char* symbol,
   const SwigV8FunctionCallback& _func) {
+#else
+SWIGRUNTIME void SWIGV8_AddStaticFunction(v8::Local<v8::Object> obj, const char* symbol,
+  const SwigV8FunctionCallback& _func) {
+#endif
   obj->Set(SWIGV8_SYMBOL_NEW(symbol), SWIGV8_FUNCTEMPLATE_NEW(_func)->GetFunction());
 }
 
 /**
  * Registers a class method with given name for a given object.
  */
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 SWIGRUNTIME void SWIGV8_AddStaticVariable(v8::Handle<v8::Object> obj, const char* symbol,
   SwigV8AccessorGetterCallback getter, SwigV8AccessorSetterCallback setter) {
+#else
+SWIGRUNTIME void SWIGV8_AddStaticVariable(v8::Local<v8::Object> obj, const char* symbol,
+  SwigV8AccessorGetterCallback getter, SwigV8AccessorSetterCallback setter) {
+#endif
 #if (V8_MAJOR_VERSION-0) < 5
   obj->SetAccessor(SWIGV8_SYMBOL_NEW(symbol), getter, setter);
 #else

--- a/Lib/javascript/v8/javascripthelpers.swg
+++ b/Lib/javascript/v8/javascripthelpers.swg
@@ -101,7 +101,13 @@ SWIGRUNTIME void SWIGV8_AddStaticFunction(v8::Handle<v8::Object> obj, const char
 SWIGRUNTIME void SWIGV8_AddStaticFunction(v8::Local<v8::Object> obj, const char* symbol,
   const SwigV8FunctionCallback& _func) {
 #endif
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903) || (SWIG_V8_VERSION < 0x0705)
   obj->Set(SWIGV8_SYMBOL_NEW(symbol), SWIGV8_FUNCTEMPLATE_NEW(_func)->GetFunction());
+#elif (SWIG_V8_VERSION < 0x0706)
+  obj->Set(SWIGV8_SYMBOL_NEW(symbol), SWIGV8_FUNCTEMPLATE_NEW(_func)->GetFunction(SWIGV8_CURRENT_CONTEXT()).ToLocalChecked());
+#else
+  obj->Set(SWIGV8_CURRENT_CONTEXT(), SWIGV8_SYMBOL_NEW(symbol), SWIGV8_FUNCTEMPLATE_NEW(_func)->GetFunction(SWIGV8_CURRENT_CONTEXT()).ToLocalChecked());
+#endif
 }
 
 /**

--- a/Lib/javascript/v8/javascriptinit.swg
+++ b/Lib/javascript/v8/javascriptinit.swg
@@ -70,14 +70,18 @@ extern "C"
 #if (NODE_MODULE_VERSION < 0x000C)
 void SWIGV8_INIT (v8::Handle<v8::Object> exports)
 #else
-void SWIGV8_INIT (v8::Handle<v8::Object> exports, v8::Handle<v8::Object> /*module*/)
+void SWIGV8_INIT (v8::Local<v8::Object> exports, v8::Local<v8::Object> /*module*/)
 #endif
 {
   SWIG_InitializeModule(static_cast<void *>(&exports));
 
   SWIGV8_HANDLESCOPE();
   
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
   v8::Handle<v8::Object> exports_obj = exports;
+#else
+  v8::Local<v8::Object> exports_obj = exports;
+#endif
 %}
 
 

--- a/Lib/javascript/v8/javascriptprimtypes.swg
+++ b/Lib/javascript/v8/javascriptprimtypes.swg
@@ -6,7 +6,11 @@
 
 %fragment(SWIG_From_frag(bool),"header") {
 SWIGINTERNINLINE
+%#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 v8::Handle<v8::Value>
+%#else
+v8::Local<v8::Value>
+%#endif
 SWIG_From_dec(bool)(bool value)
 {
   return SWIGV8_BOOLEAN_NEW(value);
@@ -16,7 +20,11 @@ SWIG_From_dec(bool)(bool value)
 %fragment(SWIG_AsVal_frag(bool),"header",
           fragment=SWIG_AsVal_frag(long)) {
 SWIGINTERN
+%#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 int SWIG_AsVal_dec(bool)(v8::Handle<v8::Value> obj, bool *val)
+%#else
+int SWIG_AsVal_dec(bool)(v8::Local<v8::Value> obj, bool *val)
+%#endif
 {
   if(!obj->IsBoolean()) {
     return SWIG_ERROR;
@@ -31,7 +39,11 @@ int SWIG_AsVal_dec(bool)(v8::Handle<v8::Value> obj, bool *val)
 
 %fragment(SWIG_From_frag(int),"header") {
 SWIGINTERNINLINE
+%#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 v8::Handle<v8::Value> SWIG_From_dec(int)(int value)
+%#else
+v8::Local<v8::Value> SWIG_From_dec(int)(int value)
+%#endif
 {
   return SWIGV8_INT32_NEW(value);
 }
@@ -39,7 +51,11 @@ v8::Handle<v8::Value> SWIG_From_dec(int)(int value)
 
 %fragment(SWIG_AsVal_frag(int),"header") {
 SWIGINTERN
+%#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 int SWIG_AsVal_dec(int)(v8::Handle<v8::Value> valRef, int* val)
+%#else
+int SWIG_AsVal_dec(int)(v8::Local<v8::Value> valRef, int* val)
+%#endif
 {
   if (!valRef->IsNumber()) {
     return SWIG_TypeError;
@@ -54,7 +70,11 @@ int SWIG_AsVal_dec(int)(v8::Handle<v8::Value> valRef, int* val)
 
 %fragment(SWIG_From_frag(long),"header") {
 SWIGINTERNINLINE
+%#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 v8::Handle<v8::Value> SWIG_From_dec(long)(long value)
+%#else
+v8::Local<v8::Value> SWIG_From_dec(long)(long value)
+%#endif
 {
   return SWIGV8_NUMBER_NEW(value);
 }
@@ -63,7 +83,11 @@ v8::Handle<v8::Value> SWIG_From_dec(long)(long value)
 %fragment(SWIG_AsVal_frag(long),"header",
           fragment="SWIG_CanCastAsInteger") {
 SWIGINTERN
+%#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 int SWIG_AsVal_dec(long)(v8::Handle<v8::Value> obj, long* val)
+%#else
+int SWIG_AsVal_dec(long)(v8::Local<v8::Value> obj, long* val)
+%#endif
 {
   if (!obj->IsNumber()) {
     return SWIG_TypeError;
@@ -79,7 +103,11 @@ int SWIG_AsVal_dec(long)(v8::Handle<v8::Value> obj, long* val)
 %fragment(SWIG_From_frag(unsigned long),"header",
           fragment=SWIG_From_frag(long)) {
 SWIGINTERNINLINE
+%#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 v8::Handle<v8::Value> SWIG_From_dec(unsigned long)(unsigned long value)
+%#else
+v8::Local<v8::Value> SWIG_From_dec(unsigned long)(unsigned long value)
+%#endif
 {
   return (value > LONG_MAX) ?
     SWIGV8_INTEGER_NEW_UNS(value) : SWIGV8_INTEGER_NEW(%numeric_cast(value,long));
@@ -89,7 +117,11 @@ v8::Handle<v8::Value> SWIG_From_dec(unsigned long)(unsigned long value)
 %fragment(SWIG_AsVal_frag(unsigned long),"header",
           fragment="SWIG_CanCastAsInteger") {
 SWIGINTERN
+%#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 int SWIG_AsVal_dec(unsigned long)(v8::Handle<v8::Value> obj, unsigned long *val)
+%#else
+int SWIG_AsVal_dec(unsigned long)(v8::Local<v8::Value> obj, unsigned long *val)
+%#endif
 {
   if(!obj->IsNumber()) {
     return SWIG_TypeError;
@@ -115,7 +147,11 @@ int SWIG_AsVal_dec(unsigned long)(v8::Handle<v8::Value> obj, unsigned long *val)
     fragment="SWIG_LongLongAvailable") {
 %#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERNINLINE
+%#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 v8::Handle<v8::Value> SWIG_From_dec(long long)(long long value)
+%#else
+v8::Local<v8::Value> SWIG_From_dec(long long)(long long value)
+%#endif
 {
   return SWIGV8_NUMBER_NEW(value);
 }
@@ -128,7 +164,11 @@ v8::Handle<v8::Value> SWIG_From_dec(long long)(long long value)
     fragment="SWIG_LongLongAvailable") {
 %#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERN
+%#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 int SWIG_AsVal_dec(long long)(v8::Handle<v8::Value> obj, long long* val)
+%#else
+int SWIG_AsVal_dec(long long)(v8::Local<v8::Value> obj, long long* val)
+%#endif
 {
   if (!obj->IsNumber()) {
     return SWIG_TypeError;
@@ -148,7 +188,11 @@ int SWIG_AsVal_dec(long long)(v8::Handle<v8::Value> obj, long long* val)
     fragment="SWIG_LongLongAvailable") {
 %#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERNINLINE
+%#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 v8::Handle<v8::Value> SWIG_From_dec(unsigned long long)(unsigned long long value)
+%#else
+v8::Local<v8::Value> SWIG_From_dec(unsigned long long)(unsigned long long value)
+%#endif
 {
   return (value > LONG_MAX) ?
     SWIGV8_INTEGER_NEW_UNS(value) : SWIGV8_INTEGER_NEW(%numeric_cast(value,long));
@@ -162,7 +206,11 @@ v8::Handle<v8::Value> SWIG_From_dec(unsigned long long)(unsigned long long value
     fragment="SWIG_LongLongAvailable") {
 %#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERN
+%#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 int SWIG_AsVal_dec(unsigned long long)(v8::Handle<v8::Value> obj, unsigned long long *val)
+%#else
+int SWIG_AsVal_dec(unsigned long long)(v8::Local<v8::Value> obj, unsigned long long *val)
+%#endif
 {
   if(!obj->IsNumber()) {
     return SWIG_TypeError;
@@ -185,7 +233,11 @@ int SWIG_AsVal_dec(unsigned long long)(v8::Handle<v8::Value> obj, unsigned long 
 
 %fragment(SWIG_From_frag(double),"header") {
 SWIGINTERN
+%#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 v8::Handle<v8::Value> SWIG_From_dec(double) (double val)
+%#else
+v8::Local<v8::Value> SWIG_From_dec(double) (double val)
+%#endif
 {
   return SWIGV8_NUMBER_NEW(val);
 }
@@ -193,7 +245,11 @@ v8::Handle<v8::Value> SWIG_From_dec(double) (double val)
 
 %fragment(SWIG_AsVal_frag(double),"header") {
 SWIGINTERN
+%#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 int SWIG_AsVal_dec(double)(v8::Handle<v8::Value> obj, double *val)
+%#else
+int SWIG_AsVal_dec(double)(v8::Local<v8::Value> obj, double *val)
+%#endif
 {
   if(!obj->IsNumber()) {
     return SWIG_TypeError;
@@ -203,4 +259,3 @@ int SWIG_AsVal_dec(double)(v8::Handle<v8::Value> obj, double *val)
   return SWIG_OK;
 }
 }
-

--- a/Lib/javascript/v8/javascriptrun.swg
+++ b/Lib/javascript/v8/javascriptrun.swg
@@ -9,8 +9,10 @@
 
 #if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031803)
 #define SWIGV8_STRING_NEW2(cstr, len) v8::String::New(cstr, len)
-#else
+#elif (SWIG_V8_VERSION < 0x0706)
 #define SWIGV8_STRING_NEW2(cstr, len) v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), cstr, v8::String::kNormalString, len)
+#else
+#define SWIGV8_STRING_NEW2(cstr, len) (v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), cstr, v8::NewStringType::kNormal, len)).ToLocalChecked()
 #endif
 
 #if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
@@ -47,12 +49,18 @@ typedef v8::PropertyCallbackInfo<v8::Value> SwigV8PropertyCallbackInfo;
 #define SWIGV8_THROW_EXCEPTION(err) v8::ThrowException(err)
 #define SWIGV8_STRING_NEW(str) v8::String::New(str)
 #define SWIGV8_SYMBOL_NEW(sym) v8::String::NewSymbol(sym)
+#elif (SWIG_V8_VERSION < 0x0706)
+#define SWIGV8_ADJUST_MEMORY(size) v8::Isolate::GetCurrent()->AdjustAmountOfExternalAllocatedMemory(size)
+#define SWIGV8_CURRENT_CONTEXT() v8::Isolate::GetCurrent()->GetCurrentContext()
+#define SWIGV8_THROW_EXCEPTION(err) v8::Isolate::GetCurrent()->ThrowException(err)
+#define SWIGV8_STRING_NEW(str) v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), str, v8::String::kNormalString)
+#define SWIGV8_SYMBOL_NEW(sym) v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), sym, v8::String::kNormalString)
 #else
 #define SWIGV8_ADJUST_MEMORY(size) v8::Isolate::GetCurrent()->AdjustAmountOfExternalAllocatedMemory(size)
 #define SWIGV8_CURRENT_CONTEXT() v8::Isolate::GetCurrent()->GetCurrentContext()
 #define SWIGV8_THROW_EXCEPTION(err) v8::Isolate::GetCurrent()->ThrowException(err)
-#define SWIGV8_STRING_NEW(str) v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), str)
-#define SWIGV8_SYMBOL_NEW(sym) v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), sym)
+#define SWIGV8_STRING_NEW(str) (v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), str, v8::NewStringType::kNormal)).ToLocalChecked()
+#define SWIGV8_SYMBOL_NEW(sym) (v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), sym, v8::NewStringType::kNormal)).ToLocalChecked()
 #endif
 
 #if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x032318)
@@ -107,7 +115,7 @@ typedef v8::PropertyCallbackInfo<v8::Value> SwigV8PropertyCallbackInfo;
 #define SWIGV8_BOOLEAN_VALUE(handle) (handle)->BooleanValue()
 #define SWIGV8_WRITE_UTF8(handle, buffer, len) (handle)->WriteUtf8(buffer, len)
 #define SWIGV8_UTF8_LENGTH(handle) (handle)->Utf8Length()
-#else
+#elif (SWIG_V8_VERSION < 0x0706)
 #define SWIGV8_TO_OBJECT(handle) (handle)->ToObject(SWIGV8_CURRENT_CONTEXT()).ToLocalChecked()
 #define SWIGV8_TO_STRING(handle) (handle)->ToString(SWIGV8_CURRENT_CONTEXT()).ToLocalChecked()
 #define SWIGV8_NUMBER_VALUE(handle) (handle)->NumberValue(SWIGV8_CURRENT_CONTEXT()).ToChecked()
@@ -115,7 +123,16 @@ typedef v8::PropertyCallbackInfo<v8::Value> SwigV8PropertyCallbackInfo;
 #define SWIGV8_BOOLEAN_VALUE(handle) (handle)->BooleanValue(SWIGV8_CURRENT_CONTEXT()).ToChecked()
 #define SWIGV8_WRITE_UTF8(handle, buffer, len) (handle)->WriteUtf8(v8::Isolate::GetCurrent(), buffer, len)
 #define SWIGV8_UTF8_LENGTH(handle) (handle)->Utf8Length(v8::Isolate::GetCurrent())
+#else
+#define SWIGV8_TO_OBJECT(handle) (handle)->ToObject(SWIGV8_CURRENT_CONTEXT()).ToLocalChecked()
+#define SWIGV8_TO_STRING(handle) (handle)->ToString(SWIGV8_CURRENT_CONTEXT()).ToLocalChecked()
+#define SWIGV8_NUMBER_VALUE(handle) (handle)->NumberValue(SWIGV8_CURRENT_CONTEXT()).ToChecked()
+#define SWIGV8_INTEGER_VALUE(handle) (handle)->IntegerValue(SWIGV8_CURRENT_CONTEXT()).ToChecked()
+#define SWIGV8_BOOLEAN_VALUE(handle) (handle)->BooleanValue(v8::Isolate::GetCurrent())
+#define SWIGV8_WRITE_UTF8(handle, buffer, len) (handle)->WriteUtf8(v8::Isolate::GetCurrent(), buffer, len)
+#define SWIGV8_UTF8_LENGTH(handle) (handle)->Utf8Length(v8::Isolate::GetCurrent())
 #endif
+
 
 /* ---------------------------------------------------------------------------
  * Error handling
@@ -381,10 +398,11 @@ SWIGRUNTIME void SWIGV8_SetPrivateData(v8::Local<v8::Object> obj, void *ptr, swi
   cdata->handle.MarkIndependent();
 #elif (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x032100)
   cdata->handle.MarkIndependent(v8::Isolate::GetCurrent());
-#else
+#elif (SWIG_V8_VERSION < 0x0706)
   cdata->handle.MarkIndependent();
+// Looks like future versions do not require that anymore:
+// https://monorail-prod.appspot.com/p/chromium/issues/detail?id=923361#c11
 #endif
-
 }
 
 #if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
@@ -448,8 +466,12 @@ SWIGRUNTIME v8::Local<v8::Value> SWIG_V8_NewPointerObj(void *ptr, swig_type_info
   }
 #endif
 
-//  v8::Handle<v8::Object> result = class_templ->InstanceTemplate()->NewInstance();
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903) || (SWIG_V8_VERSION < 0x0705)
   v8::Local<v8::Object> result = class_templ->InstanceTemplate()->NewInstance();
+#else
+  v8::Local<v8::Object> result = class_templ->InstanceTemplate()->NewInstance(SWIGV8_CURRENT_CONTEXT()).ToLocalChecked();
+#endif
+
   SWIGV8_SetPrivateData(result, ptr, info, flags);
 
   SWIGV8_ESCAPE(result);
@@ -704,8 +726,10 @@ v8::Local<v8::Value> SWIGV8_NewPackedObj(void *data, size_t size, swig_type_info
   cdata->handle.MarkIndependent();
 #elif (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x032100)
   cdata->handle.MarkIndependent(v8::Isolate::GetCurrent());
-#else
+#elif (SWIG_V8_VERSION < 0x0706)
   cdata->handle.MarkIndependent();
+// Looks like future versions do not require that anymore:
+// https://monorail-prod.appspot.com/p/chromium/issues/detail?id=923361#c11
 #endif
 
   SWIGV8_ESCAPE(obj);
@@ -737,7 +761,12 @@ v8::Local<v8::Value> SWIGV8_AppendOutput(v8::Local<v8::Value> result, v8::Local<
 #else  
   v8::Local<v8::Array> arr = v8::Local<v8::Array>::Cast(result);
 #endif
+
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903) || (SWIG_V8_VERSION < 0x0706)
   arr->Set(arr->Length(), obj);
+#else
+  arr->Set(SWIGV8_CURRENT_CONTEXT(), arr->Length(), obj);
+#endif
 
   SWIGV8_ESCAPE(arr);
 }

--- a/Lib/javascript/v8/javascriptrun.swg
+++ b/Lib/javascript/v8/javascriptrun.swg
@@ -163,7 +163,11 @@ public:
         SWIGV8_THROW_EXCEPTION(err);
     }
   }
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
   v8::Handle<v8::Value> err;
+#else
+  v8::Local<v8::Value> err;
+#endif
 };
 
 /* ---------------------------------------------------------------------------
@@ -228,7 +232,11 @@ public:
 
 SWIGRUNTIME v8::Persistent<v8::FunctionTemplate> SWIGV8_SWIGTYPE_Proxy_class_templ;
 
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 SWIGRUNTIME int SWIG_V8_ConvertInstancePtr(v8::Handle<v8::Object> objRef, void **ptr, swig_type_info *info, int flags) {
+#else
+SWIGRUNTIME int SWIG_V8_ConvertInstancePtr(v8::Local<v8::Object> objRef, void **ptr, swig_type_info *info, int flags) {
+#endif
   SWIGV8_HANDLESCOPE();
 
   if(objRef->InternalFieldCount() < 1) return SWIG_ERROR;
@@ -280,11 +288,19 @@ SWIGRUNTIME void SWIGV8_Proxy_DefaultDtor(const v8::WeakCallbackInfo<SWIGV8_Prox
   delete proxy;
 }
 
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 SWIGRUNTIME int SWIG_V8_GetInstancePtr(v8::Handle<v8::Value> valRef, void **ptr) {
+#else
+SWIGRUNTIME int SWIG_V8_GetInstancePtr(v8::Local<v8::Value> valRef, void **ptr) {
+#endif
   if(!valRef->IsObject()) {
     return SWIG_TypeError;
   }
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
   v8::Handle<v8::Object> objRef = SWIGV8_TO_OBJECT(valRef);
+#else
+  v8::Local<v8::Object> objRef = SWIGV8_TO_OBJECT(valRef);
+#endif
 
   if(objRef->InternalFieldCount() < 1) return SWIG_ERROR;
 
@@ -304,7 +320,11 @@ SWIGRUNTIME int SWIG_V8_GetInstancePtr(v8::Handle<v8::Value> valRef, void **ptr)
   return SWIG_OK;
 }
 
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 SWIGRUNTIME void SWIGV8_SetPrivateData(v8::Handle<v8::Object> obj, void *ptr, swig_type_info *info, int flags) {
+#else
+SWIGRUNTIME void SWIGV8_SetPrivateData(v8::Local<v8::Object> obj, void *ptr, swig_type_info *info, int flags) {
+#endif
   SWIGV8_Proxy *cdata = new SWIGV8_Proxy();
   cdata->swigCObject = ptr;
   cdata->swigCMemOwn = (flags & SWIG_POINTER_OWN) ? 1 : 0;
@@ -367,7 +387,11 @@ SWIGRUNTIME void SWIGV8_SetPrivateData(v8::Handle<v8::Object> obj, void *ptr, sw
 
 }
 
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 SWIGRUNTIME int SWIG_V8_ConvertPtr(v8::Handle<v8::Value> valRef, void **ptr, swig_type_info *info, int flags) {
+#else
+SWIGRUNTIME int SWIG_V8_ConvertPtr(v8::Local<v8::Value> valRef, void **ptr, swig_type_info *info, int flags) {
+#endif
   SWIGV8_HANDLESCOPE();
   
   /* special case: JavaScript null => C NULL pointer */
@@ -378,14 +402,26 @@ SWIGRUNTIME int SWIG_V8_ConvertPtr(v8::Handle<v8::Value> valRef, void **ptr, swi
   if(!valRef->IsObject()) {
     return SWIG_TypeError;
   }
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
   v8::Handle<v8::Object> objRef = SWIGV8_TO_OBJECT(valRef);
+#else
+  v8::Local<v8::Object> objRef = SWIGV8_TO_OBJECT(valRef);
+#endif
   return SWIG_V8_ConvertInstancePtr(objRef, ptr, info, flags);
 }
 
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 SWIGRUNTIME v8::Handle<v8::Value> SWIG_V8_NewPointerObj(void *ptr, swig_type_info *info, int flags) {
+#else
+SWIGRUNTIME v8::Local<v8::Value> SWIG_V8_NewPointerObj(void *ptr, swig_type_info *info, int flags) {
+#endif
   SWIGV8_HANDLESCOPE_ESC();
   
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
   v8::Handle<v8::FunctionTemplate> class_templ;
+#else
+  v8::Local<v8::FunctionTemplate> class_templ;
+#endif
 
   if (ptr == NULL) {
 #if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
@@ -433,7 +469,11 @@ SWIGRUNTIME v8::Handle<v8::Value> SWIG_V8_NewPointerObj(void *ptr, swig_type_inf
 SWIGRUNTIME SwigV8ReturnValue _SWIGV8_wrap_equals(const SwigV8Arguments &args) {
   SWIGV8_HANDLESCOPE();
   
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
   v8::Handle<v8::Value> jsresult;
+#else
+  v8::Local<v8::Value> jsresult;
+#endif
   void *arg1 = (void *) 0 ;
   void *arg2 = (void *) 0 ;
   bool result;
@@ -463,7 +503,11 @@ fail:
 SWIGRUNTIME SwigV8ReturnValue _wrap_getCPtr(const SwigV8Arguments &args) {
   SWIGV8_HANDLESCOPE();
   
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
   v8::Handle<v8::Value> jsresult;
+#else
+  v8::Local<v8::Value> jsresult;
+#endif
   void *arg1 = (void *) 0 ;
   long result;
   int res1;
@@ -502,10 +546,18 @@ public:
 };
 
 SWIGRUNTIMEINLINE
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 int SwigV8Packed_Check(v8::Handle<v8::Value> valRef) {
+#else
+int SwigV8Packed_Check(v8::Local<v8::Value> valRef) {
+#endif
   SWIGV8_HANDLESCOPE();
   
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
   v8::Handle<v8::Object> objRef = SWIGV8_TO_OBJECT(valRef);
+#else
+  v8::Local<v8::Object> objRef = SWIGV8_TO_OBJECT(valRef);
+#endif
   if(objRef->InternalFieldCount() < 1) return false;
 #if (V8_MAJOR_VERSION-0) < 5
   v8::Handle<v8::Value> flag = objRef->GetHiddenValue(SWIGV8_STRING_NEW("__swig__packed_data__"));
@@ -519,13 +571,21 @@ int SwigV8Packed_Check(v8::Handle<v8::Value> valRef) {
 }
 
 SWIGRUNTIME
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 swig_type_info *SwigV8Packed_UnpackData(v8::Handle<v8::Value> valRef, void *ptr, size_t size) {
+#else
+swig_type_info *SwigV8Packed_UnpackData(v8::Local<v8::Value> valRef, void *ptr, size_t size) {
+#endif
   if (SwigV8Packed_Check(valRef)) {
     SWIGV8_HANDLESCOPE();
     
     SwigV8PackedData *sobj;
 
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
     v8::Handle<v8::Object> objRef = SWIGV8_TO_OBJECT(valRef);
+#else
+    v8::Local<v8::Object> objRef = SWIGV8_TO_OBJECT(valRef);
+#endif
 
 #if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031511)
     v8::Handle<v8::Value> cdataRef = objRef->GetInternalField(0);
@@ -542,7 +602,11 @@ swig_type_info *SwigV8Packed_UnpackData(v8::Handle<v8::Value> valRef, void *ptr,
 }
 
 SWIGRUNTIME
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 int SWIGV8_ConvertPacked(v8::Handle<v8::Value> valRef, void *ptr, size_t sz, swig_type_info *ty) {
+#else
+int SWIGV8_ConvertPacked(v8::Local<v8::Value> valRef, void *ptr, size_t sz, swig_type_info *ty) {
+#endif
   swig_type_info *to = SwigV8Packed_UnpackData(valRef, ptr, sz);
   if (!to) return SWIG_ERROR;
   if (ty) {
@@ -590,7 +654,11 @@ SWIGRUNTIME void _wrap_SwigV8PackedData_delete(const v8::WeakCallbackInfo<SwigV8
 }
 
 SWIGRUNTIME
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 v8::Handle<v8::Value> SWIGV8_NewPackedObj(void *data, size_t size, swig_type_info *type) {
+#else
+v8::Local<v8::Value> SWIGV8_NewPackedObj(void *data, size_t size, swig_type_info *type) {
+#endif
   SWIGV8_HANDLESCOPE_ESC();
 
   SwigV8PackedData *cdata = new SwigV8PackedData(data, size, type);
@@ -657,7 +725,7 @@ SWIGRUNTIME
 #if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 v8::Handle<v8::Value> SWIGV8_AppendOutput(v8::Handle<v8::Value> result, v8::Handle<v8::Value> obj) {
 #else
-v8::Handle<v8::Value> SWIGV8_AppendOutput(v8::Local<v8::Value> result, v8::Handle<v8::Value> obj) {
+v8::Local<v8::Value> SWIGV8_AppendOutput(v8::Local<v8::Value> result, v8::Local<v8::Value> obj) {
 #endif
   SWIGV8_HANDLESCOPE_ESC();
   

--- a/Lib/javascript/v8/javascriptrun.swg
+++ b/Lib/javascript/v8/javascriptrun.swg
@@ -75,6 +75,7 @@ typedef v8::PropertyCallbackInfo<v8::Value> SwigV8PropertyCallbackInfo;
 #define SWIGV8_NUMBER_NEW(num) v8::Number::New(num)
 #define SWIGV8_OBJECT_NEW() v8::Object::New()
 #define SWIGV8_UNDEFINED() v8::Undefined()
+#define SWIGV8_OBJECT v8::Handle<v8::Value>
 #define SWIGV8_NULL() v8::Null()
 #else
 #define SWIGV8_ARRAY_NEW() v8::Array::New(v8::Isolate::GetCurrent())
@@ -88,6 +89,7 @@ typedef v8::PropertyCallbackInfo<v8::Value> SwigV8PropertyCallbackInfo;
 #define SWIGV8_NUMBER_NEW(num) v8::Number::New(v8::Isolate::GetCurrent(), num)
 #define SWIGV8_OBJECT_NEW() v8::Object::New(v8::Isolate::GetCurrent())
 #define SWIGV8_UNDEFINED() v8::Undefined(v8::Isolate::GetCurrent())
+#define SWIGV8_OBJECT v8::Local<v8::Value>
 #define SWIGV8_NULL() v8::Null(v8::Isolate::GetCurrent())
 #endif
 

--- a/Lib/javascript/v8/javascriptruntime.swg
+++ b/Lib/javascript/v8/javascriptruntime.swg
@@ -56,6 +56,11 @@
 %insert(runtime) %{
 #include <v8.h>
 
+#if defined(V8_MAJOR_VERSION) && defined(V8_MINOR_VERSION)
+#undef SWIG_V8_VERSION
+#define SWIG_V8_VERSION (V8_MAJOR_VERSION * 256 + V8_MINOR_VERSION)
+#endif
+
 #include <errno.h>
 #include <limits.h>
 #include <stdlib.h>

--- a/Lib/javascript/v8/javascriptstrings.swg
+++ b/Lib/javascript/v8/javascriptstrings.swg
@@ -4,10 +4,18 @@
  * ------------------------------------------------------------ */
 %fragment("SWIG_AsCharPtrAndSize", "header", fragment="SWIG_pchar_descriptor") {
 SWIGINTERN int
+%#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 SWIG_AsCharPtrAndSize(v8::Handle<v8::Value> valRef, char** cptr, size_t* psize, int *alloc)
+%#else
+SWIG_AsCharPtrAndSize(v8::Local<v8::Value> valRef, char** cptr, size_t* psize, int *alloc)
+%#endif
 {
   if(valRef->IsString()) {
+%#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
     v8::Handle<v8::String> js_str = SWIGV8_TO_STRING(valRef);
+%#else
+    v8::Local<v8::String> js_str = SWIGV8_TO_STRING(valRef);
+%#endif
 
     size_t len = SWIGV8_UTF8_LENGTH(js_str) + 1;
     char* cstr = new char[len];
@@ -20,7 +28,11 @@ SWIG_AsCharPtrAndSize(v8::Handle<v8::Value> valRef, char** cptr, size_t* psize, 
     return SWIG_OK;
   } else {
     if(valRef->IsObject()) {
+%#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
       v8::Handle<v8::Object> obj = SWIGV8_TO_OBJECT(valRef);
+%#else
+      v8::Local<v8::Object> obj = SWIGV8_TO_OBJECT(valRef);
+%#endif
       // try if the object is a wrapped char[]
       swig_type_info* pchar_descriptor = SWIG_pchar_descriptor();
       if (pchar_descriptor) {
@@ -41,7 +53,11 @@ SWIG_AsCharPtrAndSize(v8::Handle<v8::Value> valRef, char** cptr, size_t* psize, 
 }
 
 %fragment("SWIG_FromCharPtrAndSize","header",fragment="SWIG_pchar_descriptor") {
+%#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 SWIGINTERNINLINE v8::Handle<v8::Value>
+%#else
+SWIGINTERNINLINE v8::Local<v8::Value>
+%#endif
 SWIG_FromCharPtrAndSize(const char* carray, size_t size)
 {
   if (carray) {
@@ -49,7 +65,11 @@ SWIG_FromCharPtrAndSize(const char* carray, size_t size)
       // TODO: handle extra long strings
       return SWIGV8_UNDEFINED();
     } else {
+%#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
       v8::Handle<v8::String> js_str = SWIGV8_STRING_NEW2(carray, size);
+%#else
+      v8::Local<v8::String> js_str = SWIGV8_STRING_NEW2(carray, size);
+%#endif
       return js_str;
     }
   } else {

--- a/Lib/javascript/v8/javascripttypemaps.swg
+++ b/Lib/javascript/v8/javascripttypemaps.swg
@@ -25,7 +25,11 @@
 
 /* Javascript types */
 
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
 #define SWIG_Object                     v8::Handle<v8::Value>
+#else
+#define SWIG_Object                     v8::Local<v8::Value>
+#endif
 #define VOID_Object                     SWIGV8_UNDEFINED()
 
 /* Overload of the output/constant/exception/dirout handling */

--- a/Lib/javascript/v8/javascripttypemaps.swg
+++ b/Lib/javascript/v8/javascripttypemaps.swg
@@ -25,11 +25,7 @@
 
 /* Javascript types */
 
-#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
-#define SWIG_Object                     v8::Handle<v8::Value>
-#else
-#define SWIG_Object                     v8::Local<v8::Value>
-#endif
+#define SWIG_Object                     SWIGV8_OBJECT
 #define VOID_Object                     SWIGV8_UNDEFINED()
 
 /* Overload of the output/constant/exception/dirout handling */


### PR DESCRIPTION
SWIG_Object needs to have a different type depending on node version, this can't be done at the SWIG preprocessor level, so instead it is defined to a macro, which can be set properly at compile time via the C++ preprocessor